### PR TITLE
Accept HTTP 201 as PUT response for now

### DIFF
--- a/lambdas/ryhti_client/ryhti_client.py
+++ b/lambdas/ryhti_client/ryhti_client.py
@@ -1657,6 +1657,20 @@ class RyhtiClient:
                 "warnings": response.json()["warnings"],
                 "detail": None,
             }
+        elif response.status_code == 201:
+            # PUT successful, but the resource is weirdly reported as created. This is
+            # not in accordance of the API specification.
+            #
+            # If we really created a new resource, that is an internal implementation
+            # detail; for the API consumer, the same resource with existing UUID has
+            # been updated. Therefore, the response *should* be HTTP 200.
+            # But let's accept HTTP 201 for now:
+            ryhti_response = {
+                "status": 201,
+                "errors": None,
+                "warnings": response.json()["warnings"],
+                "detail": None,
+            }
         else:
             try:
                 # API errors always contain JSON
@@ -1710,7 +1724,7 @@ class RyhtiClient:
             elif get_response.status_code == 200:
                 LOGGER.info(
                     f"Plan matter {permanent_id} found! "
-                    "Checking if plan matter phase exits..."
+                    "Checking if plan matter phase exists..."
                 )
                 phases: List[RyhtiPlanMatterPhase] = get_response.json()[
                     "planMatterPhases"
@@ -1751,8 +1765,8 @@ class RyhtiClient:
                     continue
                 # 3) If plan matter phase existed, update plan matter phase instead
                 LOGGER.info(
-                    f"Plan matter phase {local_lifecycle_status} found! "
-                    "Updating phase..."
+                    f"Plan matter phase {current_phase['planMatterPhaseKey']} "
+                    f"with status {local_lifecycle_status} found! Updating phase..."
                 )
                 # Use existing phase id:
                 local_phase["planMatterPhaseKey"] = current_phase["planMatterPhaseKey"]

--- a/test/test_ryhti_client.py
+++ b/test/test_ryhti_client.py
@@ -329,7 +329,9 @@ def mock_xroad_ryhti_update_existing_plan_matter(
             "Accept": "application/json",
             "Content-type": "application/json",
         },
-        status_code=200,
+        # TODO: Currently, Ryhti responses with HTTP 201 to PUT requests. Change this back to
+        # HTTP 200 when Ryhti API is fixed, or the API spec is updated:
+        status_code=201,
     )
     # New phase may be created.
     requests_mock.post(
@@ -1027,4 +1029,7 @@ def test_save_update_existing_matter_phase_post_responses(
     )
     session.refresh(plan_instance)
     assert plan_instance.exported_at
-    assert plan_instance.validation_errors == "Kaava-asian vaihe on päivitetty Ryhtiin."
+    # TODO: switch to using correct message once Ryhti responds correctly. Currently, Ryhti
+    # claims a new phase is created every time the existing phase is updated.
+    # assert plan_instance.validation_errors == "Kaava-asian vaihe on päivitetty Ryhtiin."
+    assert plan_instance.validation_errors == "Uusi kaava-asian vaihe on viety Ryhtiin."


### PR DESCRIPTION
Ryhti API returns HTTP 201 to PUT for now. Accept this until the API is fixed.