### PR TITLE
Fix undeclared reference errors

### DIFF
--- a/infra/cloudwatch.tf
+++ b/infra/cloudwatch.tf
@@ -43,17 +43,9 @@ resource "aws_cloudwatch_event_rule" "lambda_koodistot" {
   tags              = local.default_tags
 }
 
-
 resource "aws_cloudwatch_event_target" "lambda_koodistot" {
   target_id = "${var.prefix}_load_koodistot"
   rule      = aws_cloudwatch_event_rule.lambda_koodistot.name
   arn       = aws_lambda_function.koodistot_loader.arn
-  input     = "{}"
-}
-
-resource "aws_cloudwatch_event_target" "lambda_ryhti_client" {
-  target_id = "${var.prefix}_run_ryhti_client"
-  rule      = aws_cloudwatch_event_rule.lambda_ryhti_client.name
-  arn       = aws_lambda_function.ryhti_client.arn
   input     = "{}"
 }

--- a/infra/lambda.tf
+++ b/infra/lambda.tf
@@ -143,13 +143,6 @@ resource "aws_lambda_provisioned_concurrency_config" "ryhti_client" {
   qualifier = aws_lambda_alias.ryhti_client_live.name
 }
 
-resource "aws_lambda_permission" "cloudwatch_call_ryhti_client" {
-    action = "lambda:InvokeFunction"
-    function_name = aws_lambda_function.ryhti_client.function_name
-    principal = "events.amazonaws.com"
-    source_arn = aws_cloudwatch_event_rule.lambda_ryhti_client.arn
-}
-
 resource "aws_lambda_permission" "api_gateway_call_ryhti_client" {
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.ryhti_client.function_name


### PR DESCRIPTION
Resource aws_cloudwatch_event_rule.lambda_ryhti_client was removed in #492 and these were inadvertently left undeleted