### PR TITLE
Fix mml loader

### DIFF
--- a/lambdas/mml_loader/mml_loader.py
+++ b/lambdas/mml_loader/mml_loader.py
@@ -15,6 +15,8 @@ from shapely.geometry import MultiPolygon, shape
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
+# SQLAlchemy needs all the models to be imported to make relationships mapper to work
+from database import codes, models  # noqa: F401
 from database.codes import AdministrativeRegion, Municipality
 from database.db_helper import DatabaseHelper, User
 


### PR DESCRIPTION
All sqlalchemy models must be imported before any attempt to configure mappers.